### PR TITLE
fix: Bad gateway by listening to `0.0.0.0` interface

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,6 @@ async function bootstrap() {
       whitelist: true,
     }),
   );
-  await app.listen(process.env.PORT ?? 3333);
+  await app.listen(process.env.PORT ?? 3333, process.env.HOST ?? '0.0.0.0');
 }
 bootstrap();


### PR DESCRIPTION
It seems the app listens only to `localhost` by default, but when using docker swarm, you need to listen to `0.0.0.0`, so I added that.